### PR TITLE
add a github ci workflow:

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  # run eslint and compare outputs with expected results
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12.2'
+      - uses: abatilo/actions-poetry@v2
+      - run: poetry install
+      - run: poetry run pytest -v
+
+  # sample tests to see if they can be built
+  test-builds:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        test_case:
+          - settings/production_settings
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/setup-buildx-action@v2
+      - run: docker buildx build . --build-arg PYTHON_VERSION=3.12.3
+        working-directory: tests/test_cases/${{ matrix.test_case }}


### PR DESCRIPTION
test: poetry run pytest -v
test-builds: docker buildx build . --build-arg PYTHON_VERSION=3.12.3

The latter can be run against any number of directories containing test results.  As these tests are not as quick as pytest, and hopefully in the near future there will be dozens if not more such directories; it makes sense to define a criteria for which directories to test.  Perhaps something along the line of:
  * Dockerfile is somewhat unique from a docker perspective (example: makes use of caching)
  * Specific test has been proven to be problematic or regression prone.

Over time, more tests can be added.  For example Rails has:
  * System test: https://github.com/fly-apps/dockerfile-rails/blob/main/.github/workflows/system-test.yml
  * Linting: https://github.com/fly-apps/dockerfile-rails/blob/main/.github/workflows/rubocop.yml