### PR TITLE
Mask ARG values before comparison, and add option to capture test results

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,12 @@ cd dockerfile-django/
 poetry shell
 pytest
 ```
+
+### Capturing test results
+
+To assist with this process, outputs of tests can be captured automatically. This is useful when adding new tests and when making a change that affects many tests. Be sure to inspect the output (e.g., by using git diff) before committing.
+
+Capturing test results is done by setting the following environment variable before running `pytest`:
+
+    TEST_CAPTURE=1
+    

--- a/tests/test_cases/collectstatic/collectstatic/Dockerfile
+++ b/tests/test_cases/collectstatic/collectstatic/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.12-slim-bullseye
+ARG PYTHON_VERSION=xxx
 
 FROM python:${PYTHON_VERSION}
 

--- a/tests/test_cases/collectstatic/collectstatic_random_secret_key/Dockerfile
+++ b/tests/test_cases/collectstatic/collectstatic_random_secret_key/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.12-slim-bullseye
+ARG PYTHON_VERSION=xxx
 
 FROM python:${PYTHON_VERSION}
 

--- a/tests/test_cases/collectstatic/no_collectstatic/Dockerfile
+++ b/tests/test_cases/collectstatic/no_collectstatic/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.12-slim-bullseye
+ARG PYTHON_VERSION=xxx
 
 FROM python:${PYTHON_VERSION}
 

--- a/tests/test_cases/database/postgres/Dockerfile
+++ b/tests/test_cases/database/postgres/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.12-slim-bullseye
+ARG PYTHON_VERSION=xxx
 
 FROM python:${PYTHON_VERSION}
 

--- a/tests/test_cases/database/sqlite/Dockerfile
+++ b/tests/test_cases/database/sqlite/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.12-slim-bullseye
+ARG PYTHON_VERSION=xxx
 
 FROM python:${PYTHON_VERSION}
 

--- a/tests/test_cases/dependency_manager_package/pip/Dockerfile
+++ b/tests/test_cases/dependency_manager_package/pip/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.12-slim-bullseye
+ARG PYTHON_VERSION=xxx
 
 FROM python:${PYTHON_VERSION}
 

--- a/tests/test_cases/dependency_manager_package/pipenv/Dockerfile
+++ b/tests/test_cases/dependency_manager_package/pipenv/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.12-slim-bullseye
+ARG PYTHON_VERSION=xxx
 
 FROM python:${PYTHON_VERSION}
 

--- a/tests/test_cases/dependency_manager_package/poetry/Dockerfile
+++ b/tests/test_cases/dependency_manager_package/poetry/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.12-slim-bullseye
+ARG PYTHON_VERSION=xxx
 
 FROM python:${PYTHON_VERSION}
 

--- a/tests/test_cases/server/daphne/Dockerfile
+++ b/tests/test_cases/server/daphne/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.12-slim-bullseye
+ARG PYTHON_VERSION=xxx
 
 FROM python:${PYTHON_VERSION}
 

--- a/tests/test_cases/server/granian/Dockerfile
+++ b/tests/test_cases/server/granian/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.12-slim-bullseye
+ARG PYTHON_VERSION=xxx
 
 FROM python:${PYTHON_VERSION}
 

--- a/tests/test_cases/server/gunicorn/Dockerfile
+++ b/tests/test_cases/server/gunicorn/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.12-slim-bullseye
+ARG PYTHON_VERSION=xxx
 
 FROM python:${PYTHON_VERSION}
 

--- a/tests/test_cases/server/hypercorn/Dockerfile
+++ b/tests/test_cases/server/hypercorn/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.12-slim-bullseye
+ARG PYTHON_VERSION=xxx
 
 FROM python:${PYTHON_VERSION}
 

--- a/tests/test_cases/server/uvicorn/Dockerfile
+++ b/tests/test_cases/server/uvicorn/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.12-slim-bullseye
+ARG PYTHON_VERSION=xxx
 
 FROM python:${PYTHON_VERSION}
 

--- a/tests/test_cases/server_type/asgi/Dockerfile
+++ b/tests/test_cases/server_type/asgi/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.12-slim-bullseye
+ARG PYTHON_VERSION=xxx
 
 FROM python:${PYTHON_VERSION}
 

--- a/tests/test_cases/server_type/wsgi/Dockerfile
+++ b/tests/test_cases/server_type/wsgi/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.12-slim-bullseye
+ARG PYTHON_VERSION=xxx
 
 FROM python:${PYTHON_VERSION}
 

--- a/tests/test_cases/server_type/wsgi_asgi/Dockerfile
+++ b/tests/test_cases/server_type/wsgi_asgi/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.12-slim-bullseye
+ARG PYTHON_VERSION=xxx
 
 FROM python:${PYTHON_VERSION}
 

--- a/tests/test_cases/settings/production_settings/Dockerfile
+++ b/tests/test_cases/settings/production_settings/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.12-slim-bullseye
+ARG PYTHON_VERSION=xxx
 
 FROM python:${PYTHON_VERSION}
 

--- a/tests/test_cases/settings/settings/Dockerfile
+++ b/tests/test_cases/settings/settings/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.12-slim-bullseye
+ARG PYTHON_VERSION=xxx
 
 FROM python:${PYTHON_VERSION}
 


### PR DESCRIPTION
Replacing ARG values with xxx enables testing with multiple versions of Python.

Capturing test results is a labor saving device for commits like this one where a single change affects multiple expected test results.  Generating new expected results and inspecting the results (with git diff) is an effective and efficient way to handle such changes.